### PR TITLE
update ppt_MakieConfig

### DIFF
--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,14 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  typos-check:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions Repository
+        uses: actions/checkout@v4
+      - name: Check spelling
+        uses: crate-ci/typos@master
+        

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+Missings = "Missings"

--- a/docs/src/makie.md
+++ b/docs/src/makie.md
@@ -25,15 +25,16 @@ properties such as figure sizes, fontsizes, and graphics format.
 The following class helps to collect them and provide them to functions below
 ```@docs
 MakieConfig
+paper_MakieConfig
 ```
 
-### creating figures with adjusted sizes and font-sizes
+### creating Makie Figures with adjusted sizes and font-sizes
 
 ```@docs
 figure_conf
 figure_conf_axis
 ```
-### saving figures to correct format and dpi-resolution
+### saving figures to correct format, subdirectory, and dpi-resolution
 
 ```@docs
 save_with_config

--- a/docs/src/makie.md
+++ b/docs/src/makie.md
@@ -10,7 +10,7 @@ The following function help to convert.
 cm2inch
 ```
 
-Figures often look well, if the ratio between length and hight corresponds
+Figures often look well, if the ratio between length and height corresponds
 to the [Golden ratio](https://en.wikipedia.org/wiki/Golden_ratio). 
 So we provide it here.
 

--- a/ext/FigureHelpersMakieAbstractMCMCExt.jl
+++ b/ext/FigureHelpersMakieAbstractMCMCExt.jl
@@ -129,7 +129,7 @@ end
 """
 Histogram of several variables of a 3D array, i.e. MCMCChain.
 
-The desnity plot may give wrong impressions, if probability mass is concentrated
+The density plot may give wrong impressions, if probability mass is concentrated
 at the borders, which can be inspected by plotting histograms instead.
 """
 function CP.histogram_params(chns, pars=names(chns, :parameters); 

--- a/ext/FigureHelpersMakieExt.jl
+++ b/ext/FigureHelpersMakieExt.jl
@@ -15,13 +15,6 @@ function CP.figure_conf_axis(args...; makie_config::MakieConfig = MakieConfig(),
     fig, Axis(fig[1,1]; kwargs...)
 end
 
-function get_size_from_config(cfg)
-    72 .* cfg.size_inches ./ cfg.pt_per_unit # size_pt
-end
-function get_fontsize_from_config(cfg)
-    cfg.fontsize ./ cfg.pt_per_unit
-end
-
 function CP.figure_conf(; makie_config::MakieConfig = MakieConfig())
     size = get_size_from_config(makie_config)
     fontsize = get_fontsize_from_config(makie_config)
@@ -48,8 +41,9 @@ function CP.save_with_config(filename::AbstractString, fig::Union{Figure, Makie.
     filename_cfg = joinpath(dir,bname)
     mkpath(dir)
     #save(filename_cfg, fig, args...)
-    save(filename_cfg, fig, args...; pt_per_unit = makie_config.pt_per_unit)
-    filename_cfg
+    save(filename_cfg, fig, args...; 
+        pt_per_unit = makie_config.pt_per_unit, px_per_unit = makie_config.px_per_unit)
+    abspath(filename_cfg)
 end
 
 CP.hidexdecoration!(ax; label = false, ticklabels = false, ticks = false, grid = false, minorgrid = false, minorticks = false, kwargs...) = hidexdecorations!(ax; label, ticklabels, ticks, grid, minorgrid, minorticks, kwargs...)

--- a/src/FigureHelpers.jl
+++ b/src/FigureHelpers.jl
@@ -7,8 +7,10 @@ include("util.jl")
 
 include("makie_util.jl")
 export cm_per_inch, cm2inch, golden_ratio, MakieConfig
-export figure_conf, figure_conf_axis, save_with_config, ppt_MakieConfig, paper_MakieConfig
+export figure_conf, figure_conf_axis, save_with_config
+export ppt_MakieConfig, paper_MakieConfig, png_MakieConfig
 export hidexdecoration!, hideydecoration!, axis_contents
+export get_size_from_config, get_fontsize_from_config
 
 include("aog_util.jl")
 export set_default_AoGTheme!, draw_with_legend!

--- a/src/aog_util.jl
+++ b/src/aog_util.jl
@@ -5,7 +5,7 @@ Setting sensible defaults with taking care of `pt_per_unit` in MakieConfig.
 
 When saving png, there is a difference in size between the produced figure 
 in print and display on a monitor and its dpi settings.
-This routine adjusts several seetings given in inch by deviding `makie_config.pt_per_unit`.
+This routine adjusts several settings given in inch by dividing `makie_config.pt_per_unit`.
 """
 function set_default_AoGTheme! end
 

--- a/src/makie_util.jl
+++ b/src/makie_util.jl
@@ -35,7 +35,7 @@ Properties and defaults
 - `px_per_unit = 2.0`
 - `filetype = "svg"`
 - `fontsize = 9`   (point units)
-- `size_inches = cm2inch.((17.5,17.5/golden_ratio))` (witdth x height)
+- `size_inches = cm2inch.((17.5,17.5/golden_ratio))` (width x height)
 
 The default `px_per_unit` needs to rescale a png image in ppt to 50%, but
 this gives better quality.
@@ -46,7 +46,7 @@ this gives better quality.
     px_per_unit::FT           = 2.0  # Makie default is 2.0, but control here
     filetype::String          = "svg" 
     fontsize::IT              = 9
-    size_inches::Tuple{FT,FT} = cm2inch.((17.5,17.5/golden_ratio)) # BG-two-collumn
+    size_inches::Tuple{FT,FT} = cm2inch.((17.5,17.5/golden_ratio)) # BG-two-column
 end
 
 # function MakieConfig(cfg::MakieConfig; 
@@ -75,7 +75,7 @@ end
 
 
 #ppt_MakieConfig(;target = :presentation, pt_per_unit = 0.75/2, filetype = "png", fontsize=18, size_inches = cm2inch.((29,29/golden_ratio)), kwargs...) = MakieConfig(;target, pt_per_unit, filetype, fontsize, size_inches, kwargs...)
-# size so that orginal size covers half a wide landscape slide of 33cm
+# size so that original size covers half a wide landscape slide of 33cm
 # svg does not work properly with fonts in ppt/wps
 #ppt_MakieConfig(;target = :presentation, filetype = "png", fontsize=18, size_inches = cm2inch.((16,16/golden_ratio)), kwargs...) = MakieConfig(;target, filetype, fontsize, size_inches, kwargs...)
 # target of 10inch wide screen slide (16:10)
@@ -132,7 +132,7 @@ the default x-width.
 
 The last constructor sets the properties without referring to a config.
 It uses by default `pt_per_unit=0.75` to conform to png display and save. 
-Remember to devide fontsize and other sizes specified elsewhere by this factor.
+Remember to divide fontsize and other sizes specified elsewhere by this factor.
 See also [`cm2inch`](@ref) and `save`.
 """    
 function figure_conf end;

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,5 +1,5 @@
 # used in Extensions to pass limimits
-"similar to passmissing, creates a function that retuns nothing, if any of its arguments is noting."
+"similar to passmissing, creates a function that returns nothing, if any of its arguments is noting."
 passnothing(f) = (xs...; kwargs...) -> any(isnothing, xs) ? nothing : f(xs...;kwargs...)
 
 # function _getindex_keep(ax::CA.AbstractAxis, syms::NTuple{N,Symbol}) where N

--- a/test/test_cairomakie.jl
+++ b/test/test_cairomakie.jl
@@ -20,8 +20,8 @@ using CairoMakie
     fig0 = figure_conf(; makie_config = ppt_MakieConfig()) 
     (x0,y0) = size(fig0.scene)
     fig = figure_conf(0.5, 1.2; makie_config = ppt_MakieConfig()) 
-    @test size(fig.scene)[1] ≈ x0*1.2
-    @test size(fig.scene)[2] ≈ x0*1.2/0.5
+    @test size(fig.scene)[1] ≈ x0*1.2 atol=1.0
+    @test size(fig.scene)[2] ≈ x0*1.2/0.5 atol=1.0
     #
     makie_config = MakieConfig(filetype="png", target=:presentation)
     # set_default_CMTheme!(;makie_config)  # aog-specific
@@ -42,6 +42,29 @@ using CairoMakie
     end
     #
 end;
+
+check_pdf_size = () -> begin
+    makie_config = paper_MakieConfig()
+    fig = figure_conf(golden_ratio;makie_config); 
+    data = cumsum(randn(4, 101), dims = 2)
+    series!(Axis(fig[1,1]), data, labels=["label $i" for i in 1:4])
+    save_with_config("tmp/tmp", fig; makie_config)
+    makie_config.size_inches
+    # load file and check property figure size-inces 
+end
+
+check_ppt_png_size = () -> begin
+    makie_config = png_MakieConfig()
+    fig = figure_conf(golden_ratio;makie_config); 
+    data = cumsum(randn(4, 101), dims = 2)
+    series!(Axis(fig[1,1]), data, labels=["label $i" for i in 1:4])
+    save_with_config("tmp/tmp", fig; makie_config)
+    makie_config.size_inches
+    # load files and check property figure size-inces is 2 times the inces
+    #
+    save_with_config("tmp/tmp", fig; makie_config=MakieConfig(makie_config; filetype="svg"))
+end
+
 
 i_test_larger_margins = () -> begin
     makie_config = ppt_MakieConfig(filetype="png")


### PR DESCRIPTION
- to widescreen (13.3inch)
- producing svg by default

save_with_config now return abolute path that allows ctrl-click open in vscode

note that png_MakieConfig uses the now default Makie px_per_unit=2.0, so that pngs (or copies from previewer) need to be rescaled to 50% in presentation (better quality during presentation)